### PR TITLE
Take care of `warning: "htole64" redefined` (and other similar warnings)

### DIFF
--- a/utils/ut_misc.h
+++ b/utils/ut_misc.h
@@ -59,6 +59,12 @@ time_t get_timezone_offset(void);
 # undef be16toh
 # undef be32toh
 # undef be64toh
+# undef htole16
+# undef htole32
+# undef htole64
+# undef le16toh
+# undef le32toh
+# undef le64toh
 
 # if __BYTE_ORDER == __LITTLE_ENDIAN
 #  define htole16(x) (x)


### PR DESCRIPTION
This PR takes care of the following warnings:

```
In file included from ut_misc.c:30:0:
ut_misc.h:64:0: warning: "htole16" redefined
 #  define htole16(x) (x)
 
In file included from /usr/include/x86_64-linux-gnu/sys/types.h:194:0,
                 from /usr/include/stdlib.h:279,
                 from ut_misc.c:13:
/usr/include/endian.h:65:0: note: this is the location of the previous definition
 #  define htole16(x) __uint16_identity (x)
 
In file included from ut_misc.c:30:0:
ut_misc.h:65:0: warning: "htole32" redefined
 #  define htole32(x) (x)
 
In file included from /usr/include/x86_64-linux-gnu/sys/types.h:194:0,
                 from /usr/include/stdlib.h:279,
                 from ut_misc.c:13:
/usr/include/endian.h:70:0: note: this is the location of the previous definition
 #  define htole32(x) __uint32_identity (x)
 
In file included from ut_misc.c:30:0:
ut_misc.h:66:0: warning: "htole64" redefined
 #  define htole64(x) (x)
 
In file included from /usr/include/x86_64-linux-gnu/sys/types.h:194:0,
                 from /usr/include/stdlib.h:279,
                 from ut_misc.c:13:
/usr/include/endian.h:75:0: note: this is the location of the previous definition
 #  define htole64(x) __uint64_identity (x)
 
In file included from ut_misc.c:30:0:
ut_misc.h:67:0: warning: "le16toh" redefined
 #  define le16toh(x) (x)
 
In file included from /usr/include/x86_64-linux-gnu/sys/types.h:194:0,
                 from /usr/include/stdlib.h:279,
                 from ut_misc.c:13:
/usr/include/endian.h:67:0: note: this is the location of the previous definition
 #  define le16toh(x) __uint16_identity (x)
 
In file included from ut_misc.c:30:0:
ut_misc.h:68:0: warning: "le32toh" redefined
 #  define le32toh(x) (x)
 
In file included from /usr/include/x86_64-linux-gnu/sys/types.h:194:0,
                 from /usr/include/stdlib.h:279,
                 from ut_misc.c:13:
/usr/include/endian.h:72:0: note: this is the location of the previous definition
 #  define le32toh(x) __uint32_identity (x)
 
In file included from ut_misc.c:30:0:
ut_misc.h:69:0: warning: "le64toh" redefined
 #  define le64toh(x) (x)
 
In file included from /usr/include/x86_64-linux-gnu/sys/types.h:194:0,
                 from /usr/include/stdlib.h:279,
                 from ut_misc.c:13:
/usr/include/endian.h:77:0: note: this is the location of the previous definition
 #  define le64toh(x) __uint64_identity (x)
```
