### PR TITLE
fix  ws order.history param error

### DIFF
--- a/accessws/aw_server.c
+++ b/accessws/aw_server.c
@@ -628,7 +628,7 @@ static int on_method_order_history(nw_ses *ses, uint64_t id, struct clt_info *in
 
     if (!info->auth)
         return send_error_require_auth(ses, id);
-    if (json_array_size(params) != 5)
+    if (json_array_size(params) != 6)
         return send_error_invalid_argument(ses, id);
 
     json_t *read_params = json_array();


### PR DESCRIPTION
according to the wiki: https://github.com/viabtc/viabtc_exchange_server/wiki/WebSocket-Protocol the mehtod: order.history  params num should be 6, not 5