### PR TITLE
Fix a bug when executing market order

### DIFF
--- a/matchengine/me_market.c
+++ b/matchengine/me_market.c
@@ -807,7 +807,7 @@ static int execute_market_bid_order(bool real, market_t *m, order_t *taker)
             push_deal_message(taker->update_time, m->name, maker, taker, price, amount, ask_fee, bid_fee, MARKET_ORDER_SIDE_BID, deal_id, m->stock, m->money);
         }
 
-        mpd_sub(taker->left, taker->left, deal, &mpd_ctx);
+        mpd_sub(taker->left, taker->left, amount, &mpd_ctx);
         mpd_add(taker->deal_stock, taker->deal_stock, amount, &mpd_ctx);
         mpd_add(taker->deal_money, taker->deal_money, deal, &mpd_ctx);
         mpd_add(taker->deal_fee, taker->deal_fee, bid_fee, &mpd_ctx);


### PR DESCRIPTION
The remaining amount of an order should be calculated by subtracting the amount of base currency that is filled.