### PR TITLE
Free mysql_conn on closing operlog

### DIFF
--- a/matchengine/me_operlog.c
+++ b/matchengine/me_operlog.c
@@ -145,6 +145,7 @@ int fini_operlog(void)
 
     usleep(100 * 1000);
     nw_job_release(job);
+    mysql_close(mysql_conn);
 
     return 0;
 }


### PR DESCRIPTION
MYSQL object is allocated but never freed.